### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,27 +6,27 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-ht1632c			KEYWORD1
+ht1632c	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-pwm			KEYWORD2
-plot			KEYWORD2
-putchar			KEYWORD2
-hscrolltext		KEYWORD2
-vscrolltext		KEYWORD2
-bezier			KEYWORD2
-line			KEYWORD2
-circle			KEYWORD2
-ellipse			KEYWORD2
-rect			KEYWORD2
-fill			KEYWORD2
-getpixel		KEYWORD2
-setfont			KEYWORD2
-putbitmap		KEYWORD2
-profile			KEYWORD2
+pwm	KEYWORD2
+plot	KEYWORD2
+putchar	KEYWORD2
+hscrolltext	KEYWORD2
+vscrolltext	KEYWORD2
+bezier	KEYWORD2
+line	KEYWORD2
+circle	KEYWORD2
+ellipse	KEYWORD2
+rect	KEYWORD2
+fill	KEYWORD2
+getpixel	KEYWORD2
+setfont	KEYWORD2
+putbitmap	KEYWORD2
+profile	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords